### PR TITLE
Update client to Odido API with profile-based endpoints and env overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # TmobileRefresh
 
-A .NET CLI utility that automatically tops up T-Mobile Netherlands daily roaming bundles for Unlimited subscriptions.
+A .NET CLI utility that automatically tops up Odido Netherlands daily roaming bundles for Unlimited subscriptions.
 
 ## What this tool does
 
-1. Authenticates with your T-Mobile username/password.
+1. Authenticates with your Odido username/password.
 2. Resolves your linked subscription endpoint.
 3. Polls roaming bundle usage.
 4. Automatically requests a new bundle when the configured one is missing or near depletion.
@@ -17,10 +17,18 @@ dotnet run -- <username> <password> [bundleCode] [estimatedBytesPerMs]
 
 Arguments:
 
-- `username` (required): Your T-Mobile login.
-- `password` (required): Your T-Mobile password.
+- `username` (required): Your Odido login.
+- `password` (required): Your Odido password.
 - `bundleCode` (optional): Bundle buying code to request. Default: `A0DAY01`.
 - `estimatedBytesPerMs` (optional): Consumption estimate used to schedule checks. Default: `25`.
+
+Optional environment variables for API compatibility:
+
+- `ODIDO_API_BASE_URL`: Explicit API base URL (defaults to trying `https://capi.odido.nl` first, then legacy `https://capi.t-mobile.nl`).
+- `ODIDO_CLIENT_ID`: Override mobile app client id.
+- `ODIDO_BASIC_AUTH_TOKEN`: Override basic auth token used by `/login`.
+- `ODIDO_SCOPE`: Override requested OAuth scope.
+- `ODIDO_USER_AGENT`: Override user-agent header.
 
 ## Build
 
@@ -31,8 +39,8 @@ dotnet build
 ## Notes
 
 - This project uses a polling-based strategy and may need tuning for your traffic profile.
-- This program is not affiliated with T-Mobile.
+- This program is not affiliated with Odido.
 
 ## Disclaimer
 
-This may not be in line with T-Mobile terms and conditions. Use at your own risk.
+This may not be in line with Odido terms and conditions. Use at your own risk.


### PR DESCRIPTION
### Motivation

- Move the client to use the new Odido API while preserving fallback compatibility with the legacy T‑Mobile API.
- Allow runtime overrides so future API changes can be accommodated without code edits.
- Provide clearer branding and instructions for Odido usage in the repo documentation.

### Description

- Prefer `https://capi.odido.nl` and fall back to `https://capi.t-mobile.nl` via a new `DefaultApiBaseUrls` array and `ApiProfile` abstraction in `Program.cs`.
- Replace hard-coded auth/UA values with environment-overridable defaults (`ODIDO_API_BASE_URL`, `ODIDO_CLIENT_ID`, `ODIDO_BASIC_AUTH_TOKEN`, `ODIDO_SCOPE`, `ODIDO_USER_AGENT`) via `GetApiProfiles()` and runtime `Environment.GetEnvironmentVariable` usage.
- Refactor authentication to iterate API profiles in `CreateSessionAsync`, and updated `RequestAuthorizationCodeAsync` and `RequestAccessTokenAsync` to accept an `ApiProfile` and use the profile's `BaseUrl`, `ClientId`, and `BasicAuthToken`.
- Update user-agent default to an Odido-style string and update `README.md` to reflect Odido branding and document the new environment variables.

### Testing

- Attempted `dotnet build` in the container which failed because `dotnet` is not installed in the environment, so compilation could not be verified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f0793bda08323ae0998200087b7eb)